### PR TITLE
Changing access to $SiteUrl array

### DIFF
--- a/provisioning/deploy.ps1
+++ b/provisioning/deploy.ps1
@@ -83,7 +83,7 @@ if ((Test-Path "$PSScriptRoot\..\solution\sharepoint\solution\sharepoint-portal-
     Write-Host "Packaging solution" -ForegroundColor Cyan 
     gulp -f "gulpfile.js" package-solution --ship 2>&1 | Out-Null
 }
-$connection = Connect-PnPOnline -Url $SiteUrl[0] -Credentials $Credentials -ReturnConnection
+$connection = Connect-PnPOnline -Url ($SiteUrl | Select -First 1) -Credentials $Credentials -ReturnConnection
 
 if ($SkipSolutionDeployment -ne $true) {
     # Temporary until schema change is present
@@ -106,10 +106,10 @@ Invoke-PnPQuery -Connection $connection
 Set-ThemeIfNotSet -Connection $connection
 
 # Register the site as the hubsite
-$isHub = Get-PnPHubSite -Identity $siteUrl[0] -ErrorAction SilentlyContinue -Connection $connection
+$isHub = Get-PnPHubSite -Identity ($SiteUrl | Select -First 1) -ErrorAction SilentlyContinue -Connection $connection
 if ($isHub -eq $null) {
     Write-Host "Registering site as hubsite" -ForegroundColor Cyan
-    Register-PnPHubSite -Site $siteUrl -Connection $connection 2>&1 | Out-Null
+    Register-PnPHubSite -Site $SiteUrl -Connection $connection 2>&1 | Out-Null
     
 }
 $HubSiteId = (Get-PnPSite -Includes Id).Id.ToString()


### PR DESCRIPTION
I ran into an issue where $SiteUrl[0] wouldn't return the first element. I changed it to use Select -First 1 which is more safe than simply acessing [0]. Subsequently Connect-PnPOnline would fail which would lead to more issues. I haven't created an issue for this yet.

#### Category
- [x] Bug Fix
- [ ] New Feature