### PR TITLE
Typo in hub site description

### DIFF
--- a/provisioning/hierarchy.json
+++ b/provisioning/hierarchy.json
@@ -1,7 +1,7 @@
 {
     "url":"portal",
     "title":"PnP SP Starter Kit",
-    "description":"PnP SP Starket Kit Hub",
+    "description":"PnP SP Starter Kit Hub",
     "children":[
         {
             "url":"hr",


### PR DESCRIPTION
#### Category
- [ ] Bug Fix
- [ ] New Feature
- [x] Typo


The site description for the hub site is possibly spelled incorrect "Starket" 
