### PR TITLE
Update wp-stock-information.md

### DIFF
--- a/documentation/components/wp-stock-information.md
+++ b/documentation/components/wp-stock-information.md
@@ -21,7 +21,7 @@ The `Stock Information` web part can be configured with the following properties
 | Label | Property | Type | Required | Description |
 | ---- | ---- | ---- | ---- | ---- |
 | Stock Code | stockSymbol | string | no | Default: MSFT - overrides the default stock, MSFT, with a preferred stock symbol |
-| Show completed tasks | autoRefresh | bool | no | Default: false - If true, the web part will auto refresh every 60 seconds |
+| Automatic Refresh | autoRefresh | bool | no | Default: false - If true, the web part will auto refresh every 60 seconds |
 
 # Installing the web part
 


### PR DESCRIPTION
Adjusted the name of the label in the documenation. The label is "Automatic Refresh" as described in the en-us.js file: https://github.com/SharePoint/sp-starter-kit/blob/master/solution/src/webparts/stockInformation/loc/en-us.js

#### Category
- [x] Bug Fix
- [ ] New Feature
- Related issues: fixes #X, partially #Y, mentioned in #Z