### PR TITLE
Tiles Web Part – Display Issue in Safari

### DIFF
--- a/solution/src/webparts/tiles/components/Tiles.module.scss
+++ b/solution/src/webparts/tiles/components/Tiles.module.scss
@@ -12,7 +12,7 @@
 
   .tilesList {
     @include ms-Grid-row;
-    display: flex;
+    display: block;
     flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
Stylesheet update to fix a Safari browser issue where tiles are wrapping to the next row unevenly.

#### Category
- [X] Bug Fix
- [ ] New Feature
- Related issues: fixes #16 

#### What's in this Pull Request?
This PR includes a minor SCSS fix which resolves a display issue in Safari web-browsers where Tiles aren't wrapping properly to new lines.