### PR TITLE
Resizing footer based on number of links

### DIFF
--- a/solution/src/extensions/portalFooter/components/Links/Links.module.scss
+++ b/solution/src/extensions/portalFooter/components/Links/Links.module.scss
@@ -13,7 +13,7 @@
   }
 
   &.visible {
-    height: 190px;
+    height: auto;
   }
 
   &.hidden {
@@ -50,5 +50,5 @@
     right: 0.5em;
     padding: 0.5em;
     min-width: 0;
-  }   
+  }
 }


### PR DESCRIPTION
#### Category
- [ x] Bug Fix
- [ ] New Feature
- Related issues: fixes #X, partially #Y, mentioned in #Z

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
> 


#### What's in this Pull Request?

> Please describe the changes in this PR. Sample description or details around bugs which are being fixed.
> If there were more than six links in one column the reminding links would not show due to the fixed height of 190px. The fixes addresses this by resizing footer based on number of links


#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
> 
> *Please target your PR to 'master' branch. Released documents are in `live` branch.*
> 
