### PR TITLE
Added New e-mail and New meeting links at the top of the personal e-mail and personal calendar webparts

### DIFF
--- a/solution/src/webparts/personalCalendar/components/PersonalCalendar.module.scss
+++ b/solution/src/webparts/personalCalendar/components/PersonalCalendar.module.scss
@@ -4,7 +4,12 @@
   @include ms-font-m;
 
   .list {
+    margin-top: 1em;
     margin-bottom: 1em;
+  }
+
+  .newMeeting {
+    padding: 0.5em 10px;
   }
 
   .meetingWrapper {

--- a/solution/src/webparts/personalCalendar/components/PersonalCalendar.tsx
+++ b/solution/src/webparts/personalCalendar/components/PersonalCalendar.tsx
@@ -194,6 +194,7 @@ export default class PersonalCalendar extends React.Component<IPersonalCalendarP
           this.state.meetings &&
             this.state.meetings.length > 0 ? (
               <div>
+                <Link href='https://outlook.office.com/owa/?#viewmodel=IComposeCalendarItemViewModelFactory' target='_blank' className={styles.newMeeting}>{strings.NewMeeting}</Link>
                 <List items={this.state.meetings}
                   onRenderCell={this._onRenderCell} className={styles.list} />
                 <Link href='https://outlook.office.com/owa/?path=/calendar/view/Day' target='_blank'>{strings.ViewAll}</Link>

--- a/solution/src/webparts/personalCalendar/loc/en-us.js
+++ b/solution/src/webparts/personalCalendar/loc/en-us.js
@@ -7,6 +7,7 @@ define([], function() {
     "Hours": "hours",
     "Loading": "Retrieving your upcoming meeting",
     "Minutes": "minutes",
+    "NewMeeting": "New meeting",
     "NoMessages": "You have no upcoming meetings",
     "NumMeetings": "How many meetings to show? 0 - show all retrieved meetings",
     "RefreshInterval": "How often to check for new upcoming meetings (in minutes)",

--- a/solution/src/webparts/personalCalendar/loc/mystrings.d.ts
+++ b/solution/src/webparts/personalCalendar/loc/mystrings.d.ts
@@ -6,6 +6,7 @@ declare interface IPersonalCalendarWebPartStrings {
   Hours: string;
   Loading: string;
   Minutes: string;
+  NewMeeting: string;
   NoMeetings: string;
   NumMeetings: string;
   RefreshInterval: string;

--- a/solution/src/webparts/personalEmail/components/PersonalEmail.module.scss
+++ b/solution/src/webparts/personalEmail/components/PersonalEmail.module.scss
@@ -1,11 +1,12 @@
 @import '~@microsoft/sp-office-ui-fabric-core/dist/sass/SPFabricCore.scss';
 
 .personalEmail {
-  .title, .viewAll {
+  .title, .viewAll, .newEmail {
     padding-left: 10px;
   }
 
   .list {
+    margin-top: 1em;
     margin-bottom: 1em;
   }
 

--- a/solution/src/webparts/personalEmail/components/PersonalEmail.tsx
+++ b/solution/src/webparts/personalEmail/components/PersonalEmail.tsx
@@ -106,6 +106,7 @@ export class PersonalEmail extends React.Component<IPersonalEmailProps, IPersona
           this.state.messages &&
             this.state.messages.length > 0 ? (
               <div>
+                <Link href='https://outlook.office.com/owa/?viewmodel=IMailComposeViewModelFactory' target='_blank' className={styles.newEmail}>{strings.NewEmail}</Link>
                 <List items={this.state.messages}
                   onRenderCell={this._onRenderCell} className={styles.list} />
                 <Link href='https://outlook.office.com/owa/' target='_blank' className={styles.viewAll}>{strings.ViewAll}</Link>

--- a/solution/src/webparts/personalEmail/loc/en-us.js
+++ b/solution/src/webparts/personalEmail/loc/en-us.js
@@ -2,6 +2,7 @@ define([], function() {
   return {
     "Error": "An error has occurred while retrieving your messages",
     "Loading": "Retrieving your messages",
+    "NewEmail": "New e-mail",
     "NoMessages": "No messages were found",
     "NrOfMessagesToShow": "Number of messages to show",
     "PropertyPaneDescription": "Messages web part configuration",

--- a/solution/src/webparts/personalEmail/loc/mystrings.d.ts
+++ b/solution/src/webparts/personalEmail/loc/mystrings.d.ts
@@ -1,6 +1,7 @@
 declare interface IPersonalEmailWebPartStrings {
   Error: string;
   Loading: string;
+  NewEmail: string;
   NoMessages: string;
   NrOfMessagesToShow: string;
   PropertyPaneDescription: string;


### PR DESCRIPTION
Added New e-mail and New meeting links at the top of the personal e-mail and personal calendar webparts

#### Category
- [ ] Bug Fix
- [x] New Feature
- Related issues: fixes #163 #162 

#### What's in this Pull Request?

Added New e-mail and New meeting links at the top of the personal e-mail and personal calendar webparts.