### PR TITLE
Change in cmd Apply-PnPProvisioningHierarchy.

### DIFF
--- a/provisioning/readme.md
+++ b/provisioning/readme.md
@@ -22,7 +22,7 @@ Connect-PnPOnline -Url https://[yourtenant].sharepoint.com
 Then the easiest way to install the starter it is by entering:
 
 ```powershell
-Apply-PnPProvisioningHierarchy -Path starterkit.pnp
+Apply-PnPTenantTemplate -Path starterkit.pnp
 ```
 
 **Common notes**
@@ -30,7 +30,7 @@ Apply-PnPProvisioningHierarchy -Path starterkit.pnp
 - By default the starter kit will create 3 site collections, using a common prefix of 'Contoso'. These sites will be called 'contosoportal' (a communications site), 'contosohr' and 'contosomarketing' (both team sites). If you want to provide a different prefix, enter the apply cmdlet as follows:
 
 ```powershell
-Apply-PnPProvisioningHierarchy -Path starterkit.pnp -Parameters @{"SitePrefixUrl"="contoso"}
+Apply-PnPTenantTemplate -Path starterkit.pnp -Parameters @{"SitePrefixUrl"="contoso"}
 ```
 
 where you replace the 'contoso' part with your own prefix, for instance the name of your company.
@@ -63,7 +63,7 @@ Credentials may be provided via the command line, or by using the ['Windows cred
 ```powershell
 $creds = Get-Credential
 Connect-PnPOnline https://[yourtenant].sharepoint.com -Credentials $creds
-Apply-PnPProvisioningHierarchy -Path .\starterkit.pnp
+Apply-PnPTenantTemplate -Path .\starterkit.pnp
 ```
 
 ## Provisioning Parameters
@@ -84,5 +84,5 @@ StockSymbol - defaults to "MSFT"
 Override one or more settings can be done like this:
 
 ```powershell
-Apply-PnPProvisioningHierarchy -Path .\starterkit.pnp -Parameters @{"Company"="Your Company Name";"SiteUrlPrefix"="YourCompany";"WeatherCity"="Stockholm"}
+Apply-PnPTenantTemplate -Path .\starterkit.pnp -Parameters @{"Company"="Your Company Name";"SiteUrlPrefix"="YourCompany";"WeatherCity"="Stockholm"}
 ```


### PR DESCRIPTION
It seems like a there is change in command, Apply-PnPProvisioningHierarchy and it has been changed to Apply-PnPTenantTemplate (https://github.com/SharePoint/PnP-PowerShell/blob/master/CHANGELOG.md. Change log : 3.3.1811.0). 
Even though it is an alias, the execution doesn't seem to be working for provisioning.

#### Category
- [  ] Bug Fix
- [ ] New Feature
- Related issues: fixes #X, partially #Y, mentioned in #Z

The command Apply-PnPProvisioningHierarchy doesn't seem to be working since we are getting error. Instead, we may have to change the README file with the command 

#### What's in this Pull Request?

We have changed all the commands from **Apply-PnPProvisioningHierarchy** to **Apply-PnPTenantTemplate** in the documentation


#### Guidance
