### PR TITLE
Portalfooter and EditDialog fix

### DIFF
--- a/solution/src/common/myLinks/MyLinksDialog.tsx
+++ b/solution/src/common/myLinks/MyLinksDialog.tsx
@@ -105,69 +105,71 @@ class MyLinksDialogContent extends
 
   public componentDidMount(): void {
     // fire the resize event to paint the content of the dialog
-    window.dispatchEvent(new Event('resize'));
+    let resizeEvent = window.document.createEvent('UIEvents');
+    resizeEvent.initUIEvent('resize', true, false, window, 0);
+    window.dispatchEvent(resizeEvent);
   }
 
   /**
    * Renders the dialog content using an Office UI Fabric grid
    */
   public render(): JSX.Element {
-    return (<div className={ styles.myLinksDialogRoot }>
+    return (<div className={styles.myLinksDialogRoot}>
       <DialogContent
-        title={ strings.MyLinksDialogTitle }
-        subText={ strings.MyLinksDialogDescription }
-        onDismiss={ this.props.cancel }
-        showCloseButton={ !this.state.showDetailPanel }>
+        title={strings.MyLinksDialogTitle}
+        subText={strings.MyLinksDialogDescription}
+        onDismiss={this.props.cancel}
+        showCloseButton={!this.state.showDetailPanel}>
 
-        <div className={ styles.myLinksDialogContent }>
+        <div className={styles.myLinksDialogContent}>
           <div className="ms-Grid">
-            { this.state.showDetailPanel ?
+            {this.state.showDetailPanel ?
               <div className="ms-Grid-row">
                 <div className="ms-Grid-col ms-u-sm12 ms-u-md12 ms-u-lg12">
                   <div className="ms-Grid">
                     <div className="ms-Grid-row">
                       <div className="ms-Grid-col ms-u-sm12 ms-u-md12 ms-u-lg12">
                         <TextField
-                          label={ strings.LinkTitleLabel }
-                          required={ true }
-                          value={ this.state.title }
-                          minLength={ 150 }
-                          className={ styles.textField }
-                          onChanged={ this._onChangedTitle }
+                          label={strings.LinkTitleLabel}
+                          required={true}
+                          value={this.state.title}
+                          minLength={150}
+                          className={styles.textField}
+                          onChanged={this._onChangedTitle}
                         />
                       </div>
                     </div>
                     <div className="ms-Grid-row">
                       <div className="ms-Grid-col ms-u-sm12 ms-u-md12 ms-u-lg12">
                         <TextField
-                          label={ strings.LinkUrlLabel }
-                          required={ true }
-                          value={ this.state.url }
-                          minLength={ 150 }
-                          className={ styles.textField }
-                          onChanged={ this._onChangedUrl }
-                          onGetErrorMessage={ this._getErrorMessageUrl }
+                          label={strings.LinkUrlLabel}
+                          required={true}
+                          value={this.state.url}
+                          minLength={150}
+                          className={styles.textField}
+                          onChanged={this._onChangedUrl}
+                          onGetErrorMessage={this._getErrorMessageUrl}
                         />
                       </div>
                     </div>
-                    <div className={ `ms-Grid-row ${styles.editPanel}` }>
+                    <div className={`ms-Grid-row ${styles.editPanel}`}>
                       <div className="ms-Grid-col ms-u-sm12 ms-u-md12 ms-u-lg12">
-                        <DefaultButton text={ strings.DialogCancelButton }
-                          title={ strings.DialogCancelButton } onClick={ this._cancelEdit } />
-                        <DefaultButton primary={ true }
-                          text={ this.state.addingNewItem ? strings.DialogAddButton : strings.DialogUpdateButton }
-                          title={ this.state.addingNewItem ? strings.DialogAddButton : strings.DialogUpdateButton }
-                          onClick={ this._saveEdit } />
+                        <DefaultButton text={strings.DialogCancelButton}
+                          title={strings.DialogCancelButton} onClick={this._cancelEdit} />
+                        <DefaultButton primary={true}
+                          text={this.state.addingNewItem ? strings.DialogAddButton : strings.DialogUpdateButton}
+                          title={this.state.addingNewItem ? strings.DialogAddButton : strings.DialogUpdateButton}
+                          onClick={this._saveEdit} />
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            : null }
-            { !this.state.showDetailPanel ?
+              : null}
+            {!this.state.showDetailPanel ?
               <div className="ms-Grid-row">
                 <div className="ms-Grid-col ms-u-sm12 ms-u-md12 ms-u-lg12">
-                  <CommandBar items={ [
+                  <CommandBar items={[
                     {
                       key: 'addRow',
                       name: strings.AddLinkCommand,
@@ -188,34 +190,34 @@ class MyLinksDialogContent extends
                       onClick: this.deleteLink,
                       disabled: (this.state.selectedLink == null),
                     },
-                  ] } />
+                  ]} />
                 </div>
               </div>
-            : null}
-            { !this.state.showDetailPanel ?
+              : null}
+            {!this.state.showDetailPanel ?
               <div className="ms-Grid-row">
                 <div className="ms-Grid-col ms-u-sm12 ms-u-md12 ms-u-lg12">
                   <DetailsList
-                    items={ this.state.links }
-                    columns={ _linksColumns }
-                    layoutMode={ DetailsListLayoutMode.justified }
-                    selection={ this._selection }
-                    selectionMode={ SelectionMode.single }
-                    selectionPreservedOnEmptyClick={ true }
-                    ariaLabelForSelectionColumn={ strings.SelectionColumnAriaLabel }
-                    ariaLabelForSelectAllCheckbox={ strings.SelectionAllColumnAriaLabel }
+                    items={this.state.links}
+                    columns={_linksColumns}
+                    layoutMode={DetailsListLayoutMode.justified}
+                    selection={this._selection}
+                    selectionMode={SelectionMode.single}
+                    selectionPreservedOnEmptyClick={true}
+                    ariaLabelForSelectionColumn={strings.SelectionColumnAriaLabel}
+                    ariaLabelForSelectAllCheckbox={strings.SelectionAllColumnAriaLabel}
                   />
                 </div>
               </div>
-            : null}
+              : null}
           </div>
         </div>
-        { !this.state.showDetailPanel ?
+        {!this.state.showDetailPanel ?
           <DialogFooter>
-              <DefaultButton text={ strings.DialogCancelButton }
-                title={ strings.DialogCancelButton } onClick={ this.props.cancel } />
-              <DefaultButton text={ strings.DialogSaveButton } primary={ true }
-                title={ strings.DialogSaveButton } onClick={() => { this.props.save(this.state.links); }} />
+            <DefaultButton text={strings.DialogCancelButton}
+              title={strings.DialogCancelButton} onClick={this.props.cancel} />
+            <DefaultButton text={strings.DialogSaveButton} primary={true}
+              title={strings.DialogSaveButton} onClick={() => { this.props.save(this.state.links); }} />
           </DialogFooter>
           : null}
       </DialogContent>
@@ -266,8 +268,8 @@ class MyLinksDialogContent extends
         newLink.title != null && newLink.title.length > 0 &&
         newLink.url != null && newLink.url.length > 0) {
 
-          // add the new item to the array of Links
-          let updatedLinks: IMyLink[] = this.state.links.concat([newLink]);
+        // add the new item to the array of Links
+        let updatedLinks: IMyLink[] = this.state.links.concat([newLink]);
 
         // update the list of links and disable the detail panel
         this.setState({
@@ -296,7 +298,7 @@ class MyLinksDialogContent extends
   private _getErrorMessageUrl(value: string): string {
     // validate the URL with a specific Regular Expression
     const regEx: RegExp = /(https)?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/;
-    return(value == null || value.length === 0 || regEx.test(value) ? "" : strings.InvalidUrlError);
+    return (value == null || value.length === 0 || regEx.test(value) ? "" : strings.InvalidUrlError);
   }
 
   @autobind
@@ -304,7 +306,7 @@ class MyLinksDialogContent extends
     if (this.state.selectedLink != null &&
       this.state.links != null &&
       this.state.links.length > 0) {
-        this._selection.toggleIndexSelected(this.state.links.indexOf(this.state.selectedLink));
+      this._selection.toggleIndexSelected(this.state.links.indexOf(this.state.selectedLink));
     }
 
     // enable the detail panel
@@ -354,8 +356,9 @@ export default class MyLinksDialog extends BaseDialog {
   /**
    * Constructor for the dialog window
    */
-  constructor(public links: Array<IMyLink>) {
-    super();
+  constructor(public links: Array<IMyLink>, public isSave?: boolean) {
+    // Blocking or else click outside causes error in 1.7
+    super({isBlocking: true});
 
     // clone the initial list of links we've got
     this.initialLinks = (this.links != null) ? this.links.concat([]) : [];
@@ -363,27 +366,33 @@ export default class MyLinksDialog extends BaseDialog {
 
   public render(): void {
     ReactDOM.render(<MyLinksDialogContent
-      links={ this.links }
-      cancel={ this._cancel }
-      save={ this._save }
+      links={this.links}
+      cancel={this._cancel}
+      save={this._save}
     />,
-    this.domElement);
+      this.domElement);
   }
 
   public getConfig(): IDialogConfiguration {
     return {
-      isBlocking: false
+      isBlocking: true
     };
   }
 
   @autobind
   private _cancel(): void {
+    this.isSave = false;
     this.links = this.initialLinks;
+    // Fix for all browsers regarding SP Dialog not being to open twice
+    ReactDOM.unmountComponentAtNode(this.domElement);
     this.close();
   }
 
   @autobind
   private _save(links: Array<IMyLink>): void {
+    this.isSave = true;
+    // Fix for all browsers regarding SP Dialog not being to open twice    
+    ReactDOM.unmountComponentAtNode(this.domElement);
     this.links = links;
     this.close();
   }

--- a/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
+++ b/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
@@ -102,16 +102,19 @@ export default class PortalFooterApplicationCustomizer
     // update the local list of links
     let resultingLinks: IMyLink[] = myLinksDialog.links;
 
-    if (this._myLinks !== resultingLinks) {
-      this._myLinks = resultingLinks;
+    // Do not save if the dialog was cancelled
+    if (myLinksDialog.isSave) {
+      if (this._myLinks !== resultingLinks) {
+        this._myLinks = resultingLinks;
 
-      // save the personal links in the UPS, if there are any updates
-      let upsService: SPUserProfileService = new SPUserProfileService(this.context);
-      result.editResult = await upsService.setUserProfileProperty(this.properties.personalItemsStorageProperty,
-        'String',
-        JSON.stringify(this._myLinks));
+        // save the personal links in the UPS, if there are any updates
+        let upsService: SPUserProfileService = new SPUserProfileService(this.context);
+        result.editResult = await upsService.setUserProfileProperty(this.properties.personalItemsStorageProperty,
+          'String',
+          JSON.stringify(this._myLinks));
 
-      result.links = await this.loadLinks();
+        result.links = await this.loadLinks();
+      }
     }
 
     return (result);

--- a/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
+++ b/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
@@ -113,10 +113,9 @@ export default class PortalFooterApplicationCustomizer
           'String',
           JSON.stringify(this._myLinks));
 
-        result.links = await this.loadLinks();
       }
     }
-
+    result.links = await this.loadLinks();
     return (result);
   }
 

--- a/solution/src/extensions/portalFooter/components/PortalFooter/PortalFooter.module.scss
+++ b/solution/src/extensions/portalFooter/components/PortalFooter/PortalFooter.module.scss
@@ -38,7 +38,7 @@
     margin-right: 0.5em;
 
     .toggleButton {
-      background-color: inherit;
+      background-color: transparent;
       border: 0;
       color: inherit;
       padding: 0;

--- a/solution/src/extensions/portalFooter/components/PortalFooter/PortalFooter.tsx
+++ b/solution/src/extensions/portalFooter/components/PortalFooter/PortalFooter.tsx
@@ -45,11 +45,12 @@ export class PortalFooter extends React.Component<IPortalFooterProps, IPortalFoo
   @autobind
   private async _handleLinksEdit(): Promise<void> {
 
-    let editResult: IPortalFooterEditResult = await this.props.onLinksEdit();
-    if (editResult != null) {
+    // Only if a editResult is provided in the result
+    let result: IPortalFooterEditResult = await this.props.onLinksEdit();
+    if (result.editResult != null) {
       this.setState({
-        myLinksSaved: editResult.editResult,
-        links: editResult.links
+        myLinksSaved: result.editResult,
+        links: result.links
       });
 
       // hide the message after 2 sec

--- a/solution/src/extensions/portalFooter/components/PortalFooter/PortalFooter.tsx
+++ b/solution/src/extensions/portalFooter/components/PortalFooter/PortalFooter.tsx
@@ -45,12 +45,11 @@ export class PortalFooter extends React.Component<IPortalFooterProps, IPortalFoo
   @autobind
   private async _handleLinksEdit(): Promise<void> {
 
-    // Only if a editResult is provided in the result
-    let result: IPortalFooterEditResult = await this.props.onLinksEdit();
-    if (result.editResult != null) {
+    let editResult: IPortalFooterEditResult = await this.props.onLinksEdit();
+    if (editResult != null) {
       this.setState({
-        myLinksSaved: result.editResult,
-        links: result.links
+        myLinksSaved: editResult.editResult,
+        links: editResult.links
       });
 
       // hide the message after 2 sec


### PR DESCRIPTION
#### Category
- [x] Bug Fix
- [ ] New Feature
- Related issues: fixes at least #102 

#### What's in this Pull Request?
With the newest realease, SPFx 1.7 and sp starter kit there have been some issues with the Portal footer.
There have been errors not being able to open the edit dialog more than once, and saving without any modifications broke the footer. 
There was also some saving made when choosing to cancel, etc. So hopefully that's improved now aswell.

I've made some fixes and some IE11 support, actually it should work in all browsers.
The only additional thing for IE11 users could be to add some polyfills if needed.
I needed the PNPJs polyfills for the footer to work in IE11, but not sure everyone would need to.
I did not include the polyfills.

These are the fixes I've made:
- Changed to UIEvents instead of Event. Should not break in IE11 anymore.
- Added `blocking` to the dialog, because clicking outside caused errors.
- Added code to unmount the dialog, so we are able to open it twice. This is a workaround to solve issues with SPFx 1.7 and basedialog.
- Changed so cancelling doesn't save to UserProfile, and no success messagebar is displayed.
- Changed so saving with no new values doesn't break, but doesn't save to userprofile either.
- Changed so only actual changes (new, edit, delete) are saved to userprofile, and ONLY then the success messagebar is displayed.
- Minor css change to display messagebar properly in IE11 aswell.

Let me know if we need changes :)
/Simon 