### PR TITLE
Fix 'MyLinksDialog opens once only' issue

### DIFF
--- a/solution/src/common/myLinks/MyLinksDialog.tsx
+++ b/solution/src/common/myLinks/MyLinksDialog.tsx
@@ -376,6 +376,13 @@ export default class MyLinksDialog extends BaseDialog {
     };
   }
 
+  protected onAfterClose(): void {
+    super.onAfterClose();
+
+    // Clean up the element for the next dialog
+    ReactDOM.unmountComponentAtNode(this.domElement);
+  }
+
   @autobind
   private _cancel(): void {
     this.links = this.initialLinks;


### PR DESCRIPTION
#### Category
- [x] Bug Fix
- [ ] New Feature
- Related issues: #236

#### What's in this Pull Request?

> This Pull request fixes the 'MyLinksDialog opens once only' issue, it adds onAfterClose and unmountComponentAtNode methods to clean up the element for the next dialog.
> 
