### PR TITLE
Fix for #272 Portal Footer, disappears after navigating away

### DIFF
--- a/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
+++ b/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
@@ -44,7 +44,7 @@ export interface IPortalFooterApplicationCustomizerProperties {
 export default class PortalFooterApplicationCustomizer
   extends BaseApplicationCustomizer<IPortalFooterApplicationCustomizerProperties> {
 
-  private static _bottomPlaceholder?: PlaceholderContent;
+  private _bottomPlaceholder?: PlaceholderContent;
   private _myLinks: IMyLink[];
 
   private _handleDispose(): void {
@@ -209,15 +209,15 @@ export default class PortalFooterApplicationCustomizer
   private async _renderPlaceHolders(): Promise<void> {
 
     // check if the application customizer has already been rendered
-    if (!PortalFooterApplicationCustomizer._bottomPlaceholder) {
+    if (!this._bottomPlaceholder) {
       // create a DOM element in the bottom placeholder for the application customizer to render
-      PortalFooterApplicationCustomizer._bottomPlaceholder = this.context.placeholderProvider
+      this._bottomPlaceholder = this.context.placeholderProvider
         .tryCreateContent(PlaceholderName.Bottom, { onDispose: this._handleDispose });
     }
 
     // if the top placeholder is not available, there is no place in the UI
     // for the app customizer to render, so quit.
-    if (!PortalFooterApplicationCustomizer._bottomPlaceholder) {
+    if (!this._bottomPlaceholder) {
       return;
     }
 
@@ -234,6 +234,6 @@ export default class PortalFooterApplicationCustomizer
     );
 
     // render the UI using a React component
-    ReactDom.render(element, PortalFooterApplicationCustomizer._bottomPlaceholder.domElement);
+    ReactDom.render(element, this._bottomPlaceholder.domElement);
   }
 }


### PR DESCRIPTION
#### Category
- [x] Bug Fix
- [ ] New Feature
- Related issues: fixes #272 

#### What's in this Pull Request?

Fix for #272 issue. 

The current implementation uses the static variable to store the placeholder.

On navigating away, the placeholder object persists, but its reference to the DOM element (where a footer component got rendered) got removed and its state changes to disposed (`isDisposed` property equals to `true`). 

When a user navigates back, the already existing placeholder object is reused. But its DOM element is undefined and the rendering of the footer component fails.

The fix changes the placeholder variable from static to an object instance. Thus the placeholder will be recreated every time a rendering occurs.