### PR TITLE
Fix for #332 My Links dialog

### DIFF
--- a/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
+++ b/solution/src/extensions/portalFooter/PortalFooterApplicationCustomizer.ts
@@ -189,18 +189,19 @@ export default class PortalFooterApplicationCustomizer
     let myLinksJson: any = await upsService.getUserProfileProperty(this.properties.personalItemsStorageProperty);
 
     // if we have personalizes links
-    if (myLinksJson != null) {
-      if (myLinksJson.length > 0) {
-        this._myLinks = JSON.parse(myLinksJson) as IMyLink[];
+    if (myLinksJson && (myLinksJson.length > 0)) {
+      this._myLinks = JSON.parse(myLinksJson) as IMyLink[];
 
-        // add all of them to the "My Links" group
-        if (this._myLinks.length > 0) {
-          result.push({
-            title: strings.MyLinks,
-            links: this._myLinks,
-          });
-        }
+      // add all of them to the "My Links" group
+      if (this._myLinks.length > 0) {
+        result.push({
+          title: strings.MyLinks,
+          links: this._myLinks,
+        });
       }
+    } else {
+      // if no personal links are available, initialize the list of personal links with an empty array
+      this._myLinks = [];
     }
 
     return (result);


### PR DESCRIPTION
#### Category
- [x] Bug Fix
- [ ] New Feature
- Related issues: fixes #332

#### What's in this Pull Request?

The fix for the #332 issue with opening Portal Footer's My Links dialog.

The reason for the problem is that for a new user profile property the value would be `undefined` which is not processed properly in the code.

The fix checks for this case and initialize personal links with an empty array in this case.