### PR TITLE
Fix for 336 collab footer saved message always displayed

### DIFF
--- a/solution/src/common/myLinks/MyLinksDialog.tsx
+++ b/solution/src/common/myLinks/MyLinksDialog.tsx
@@ -352,16 +352,19 @@ export default class MyLinksDialog extends BaseDialog {
 
   // to keep track of the initial links in case user will cancel
   private initialLinks: IMyLink[];
+  public links: IMyLink[];
+  public isSave: boolean;
 
   /**
    * Constructor for the dialog window
    */
-  constructor(public links: Array<IMyLink>, public isSave?: boolean) {
+  constructor(links: Array<IMyLink>) {
     // Blocking or else click outside causes error in 1.7
     super({isBlocking: true});
 
     // clone the initial list of links we've got
-    this.initialLinks = (this.links != null) ? this.links.concat([]) : [];
+    this.initialLinks = (links != null) ? links.concat([]) : [];
+    this.links = (links != null) ? links.concat([]) : [];
   }
 
   public render(): void {
@@ -391,7 +394,7 @@ export default class MyLinksDialog extends BaseDialog {
   @autobind
   private _save(links: Array<IMyLink>): void {
     this.isSave = true;
-    // Fix for all browsers regarding SP Dialog not being to open twice    
+    // Fix for all browsers regarding SP Dialog not being to open twice
     ReactDOM.unmountComponentAtNode(this.domElement);
     this.links = links;
     this.close();

--- a/solution/src/extensions/collabFooter/CollabFooterApplicationCustomizer.ts
+++ b/solution/src/extensions/collabFooter/CollabFooterApplicationCustomizer.ts
@@ -142,19 +142,10 @@ export default class CollabFooterApplicationCustomizer
     const myLinksDialog: MyLinksDialog = new MyLinksDialog(this._myLinks);
     await myLinksDialog.show();
 
-    // update the local list of links
-    let resultingLinks: IMyLink[] = myLinksDialog.links;
-
-    if (this._myLinks !== resultingLinks) {
-      this._myLinks = resultingLinks;
-
-      // map the taxonomy items to the menu items
-      this._myLinksMenuItems = this._myLinks.map((i) => {
-        return(this.projectMyLinkToMenuItem(i, ContextualMenuItemType.Normal));
-      });
-
-      // update the result
-      result.myLinks = this._myLinksMenuItems;
+    if (myLinksDialog.isSave)
+    {
+      // update the local list of links
+      this._myLinks = myLinksDialog.links;
 
       // save the personal links in the UPS, if there are any updates
       let upsService: SPUserProfileService = new SPUserProfileService(this.context);
@@ -162,6 +153,14 @@ export default class CollabFooterApplicationCustomizer
         'String',
         JSON.stringify(this._myLinks));
     }
+
+    // map the taxonomy items to the menu items
+    this._myLinksMenuItems = this._myLinks.map((i) => {
+      return(this.projectMyLinkToMenuItem(i, ContextualMenuItemType.Normal));
+    });
+
+    // update the result
+    result.myLinks = this._myLinksMenuItems;
 
     return (result);
   }


### PR DESCRIPTION
#### Category
- [x] Bug Fix
- [ ] New Feature
- Related issues: fixes #336

#### What's in this Pull Request?

This PR fixes #336.

The reason for the issue is that in `CollabFooterApplicationCustomizer._editMyLinks()` function when checking whether to save data from My Links dialog, the code compares two lists for equality - initial links and links returned by dialog. If two lists are not equal then we need to save. But these lists will always be different as `MyLinksDialog` creates a copy of an initial list called `initialLinks` in its constructor and returns that list in case of "Cancel".

The fix for that includes two actions:
First, is to check dialog.isSave property instead of comparing lists, thus saving only when a user selected "Save" action. In case of "Cancel", `isSave` will be false and we keep the current list of links in `_myLinks` unmodified.

Second, in `MyLinksDialog` constructor we need to create copy for links that are passed as an argument instead of using them directly. This way, we will not modify a list of links that is `CollabFooterApplicationCustomizer._myLinks` when adding/deleting links without saving.